### PR TITLE
Make automatic sending of sessionId optional.

### DIFF
--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -79,6 +79,7 @@ class Parse {
       String clientKey,
       String masterKey,
       String sessionId,
+      bool autoSendSessionId,
       SecurityContext securityContext}) {
     ParseCoreData.init(appId, serverUrl,
         debug: debug,
@@ -87,6 +88,7 @@ class Parse {
         masterKey: masterKey,
         clientKey: clientKey,
         sessionId: sessionId,
+        autoSendSessionId: autoSendSessionId,
         securityContext: securityContext);
 
     _hasBeenInitialized = true;
@@ -97,12 +99,15 @@ class Parse {
   bool hasParseBeenInitialized() => _hasBeenInitialized;
 
   Future<ParseResponse> healthCheck(
-      {bool debug, ParseHTTPClient client}) async {
+      {bool debug, ParseHTTPClient client, bool autoSendSessionId}) async {
     ParseResponse parseResponse;
 
     bool _debug = isDebugEnabled(objectLevelDebug: debug);
-    ParseHTTPClient _client =
-        client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    ParseHTTPClient _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId:
+                autoSendSessionId ?? ParseCoreData().autoSendSessionId,
+            securityContext: ParseCoreData().securityContext);
 
     try {
       var response =

--- a/lib/src/data/parse_core_data.dart
+++ b/lib/src/data/parse_core_data.dart
@@ -17,6 +17,7 @@ class ParseCoreData {
       masterKey,
       clientKey,
       sessionId,
+      autoSendSessionId,
       securityContext}) {
     _instance = ParseCoreData._init(appId, serverUrl);
 
@@ -26,6 +27,8 @@ class ParseCoreData {
     if (clientKey != null) _instance.clientKey = clientKey;
     if (masterKey != null) _instance.masterKey = masterKey;
     if (sessionId != null) _instance.sessionId = sessionId;
+    if (autoSendSessionId != null)
+      _instance.autoSendSessionId = autoSendSessionId;
     if (securityContext != null) _instance.securityContext = securityContext;
   }
 
@@ -36,6 +39,7 @@ class ParseCoreData {
   String masterKey;
   String clientKey;
   String sessionId;
+  bool autoSendSessionId;
   SecurityContext securityContext;
   bool debug;
   SharedPreferences storage;

--- a/lib/src/network/parse_http_client.dart
+++ b/lib/src/network/parse_http_client.dart
@@ -3,12 +3,15 @@ part of flutter_parse_sdk;
 /// Creates a custom version of HTTP Client that has Parse Data Preset
 class ParseHTTPClient extends BaseClient {
   final Client _client;
+  final bool _autoSendSessionId;
   final String _userAgent = "$keyLibraryName $keySdkVersion";
   ParseCoreData data = ParseCoreData();
   Map<String, String> additionalHeaders;
 
-  ParseHTTPClient([SecurityContext securityContext])
-      : _client = securityContext != null
+  ParseHTTPClient(
+      {bool autoSendSessionId = false, SecurityContext securityContext})
+      : _autoSendSessionId = autoSendSessionId,
+        _client = securityContext != null
             ? IOClient(HttpClient(context: securityContext))
             : IOClient();
 
@@ -17,7 +20,8 @@ class ParseHTTPClient extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) {
     request.headers[keyHeaderUserAgent] = _userAgent;
     request.headers[keyHeaderApplicationId] = data.applicationId;
-    if ((data.sessionId != null) &&
+    if ((_autoSendSessionId == true) &&
+        (data.sessionId != null) &&
         (request.headers[keyHeaderSessionToken] == null))
       request.headers[keyHeaderSessionToken] = data.sessionId;
 

--- a/lib/src/objects/parse_config.dart
+++ b/lib/src/objects/parse_config.dart
@@ -2,9 +2,14 @@ part of flutter_parse_sdk;
 
 class ParseConfig extends ParseObject {
   /// Creates an instance of ParseConfig so that you can grab all configs from the server
-  ParseConfig({bool debug, ParseHTTPClient client}) : super('config') {
+  ParseConfig({bool debug, ParseHTTPClient client, bool autoSendSessionId})
+      : super('config') {
     _debug = isDebugEnabled(objectLevelDebug: debug);
-    _client = client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId:
+                autoSendSessionId ?? ParseCoreData().autoSendSessionId,
+            securityContext: ParseCoreData().securityContext);
   }
 
   /// Gets all configs from the server

--- a/lib/src/objects/parse_file.dart
+++ b/lib/src/objects/parse_file.dart
@@ -21,10 +21,18 @@ class ParseFile extends ParseObject {
   ///
   /// {https://docs.parseplatform.org/rest/guide/#files/}
   ParseFile(this.file,
-      {String name, String url, bool debug, ParseHTTPClient client})
+      {String name,
+      String url,
+      bool debug,
+      ParseHTTPClient client,
+      bool autoSendSessionId})
       : super(keyFile) {
     _debug = isDebugEnabled(objectLevelDebug: debug);
-    _client = client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId:
+                autoSendSessionId ?? ParseCoreData().autoSendSessionId,
+            securityContext: ParseCoreData().securityContext);
 
     if (file != null) {
       this.name = path.basename(file.path);

--- a/lib/src/objects/parse_function.dart
+++ b/lib/src/objects/parse_function.dart
@@ -9,12 +9,17 @@ class ParseCloudFunction extends ParseObject {
   /// Creates a new cloud function object
   ///
   /// {https://docs.parseplatform.org/cloudcode/guide/}
-  ParseCloudFunction(this.functionName, {bool debug, ParseHTTPClient client})
+  ParseCloudFunction(this.functionName,
+      {bool debug, ParseHTTPClient client, bool autoSendSessionId})
       : super(functionName) {
     _path = "/functions/$functionName";
 
     _debug = isDebugEnabled(objectLevelDebug: debug);
-    _client = client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId:
+                autoSendSessionId ?? ParseCoreData().autoSendSessionId,
+            securityContext: ParseCoreData().securityContext);
   }
 
   /// Executes a cloud function

--- a/lib/src/objects/parse_geo_point.dart
+++ b/lib/src/objects/parse_geo_point.dart
@@ -9,13 +9,18 @@ class ParseGeoPoint extends ParseObject {
       {double latitude = 0.0,
       double longitude = 0.0,
       bool debug,
-      ParseHTTPClient client})
+      ParseHTTPClient client,
+      bool autoSendSessionId})
       : super(keyGeoPoint) {
     _latitude = latitude;
     _longitude = longitude;
 
     _debug = isDebugEnabled(objectLevelDebug: debug);
-    _client = client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId:
+                autoSendSessionId ?? ParseCoreData().autoSendSessionId,
+            securityContext: ParseCoreData().securityContext);
   }
 
   double get latitude => _latitude;

--- a/lib/src/objects/parse_object.dart
+++ b/lib/src/objects/parse_object.dart
@@ -15,13 +15,18 @@ class ParseObject extends ParseBase implements ParseCloneable {
   /// [String] className refers to the Table Name in your Parse Server,
   /// [bool] debug will overwrite the current default debug settings and
   /// [ParseHttpClient] can be overwritten to create your own HTTP Client
-  ParseObject(String className, {bool debug: false, ParseHTTPClient client})
+  ParseObject(String className,
+      {bool debug: false, ParseHTTPClient client, bool autoSendSessionId})
       : super() {
     setClassName(className);
     _path = "$keyEndPointClasses$className";
 
     _debug = isDebugEnabled(objectLevelDebug: debug);
-    _client = client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId:
+                autoSendSessionId ?? ParseCoreData().autoSendSessionId,
+            securityContext: ParseCoreData().securityContext);
   }
 
   String toPointer() => parseEncode(this);

--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -44,7 +44,10 @@ class ParseUser extends ParseObject implements ParseCloneable {
       {bool debug, ParseHTTPClient client})
       : super(keyClassUser) {
     _debug = isDebugEnabled(objectLevelDebug: debug);
-    _client = client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId: true,
+            securityContext: ParseCoreData().securityContext);
 
     this.username = username;
     this.password = password;
@@ -65,8 +68,10 @@ class ParseUser extends ParseObject implements ParseCloneable {
   static Future<ParseResponse> getCurrentUserFromServer(
       {String token, bool debug, ParseHTTPClient client}) async {
     bool _debug = isDebugEnabled(objectLevelDebug: debug);
-    ParseHTTPClient _client =
-        client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    ParseHTTPClient _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId: true,
+            securityContext: ParseCoreData().securityContext);
 
     // We can't get the current user and session without a sessionId
     if ((ParseCoreData().sessionId == null) && (token == null)) {
@@ -272,8 +277,10 @@ class ParseUser extends ParseObject implements ParseCloneable {
     var emptyUser = ParseUser(null, null, null);
 
     bool _debug = isDebugEnabled(objectLevelDebug: debug);
-    ParseHTTPClient _client =
-        client ?? ParseHTTPClient(ParseCoreData().securityContext);
+    ParseHTTPClient _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId: true,
+            securityContext: ParseCoreData().securityContext);
 
     try {
       final response = await _client.get("${ParseCoreData().serverUrl}/$path");


### PR DESCRIPTION
Make the automatic sending of sessonId in headers optional, can be set globally and later overwritten for each object. Only for User Objects it is always true. So per default this should be the same behaviour as before my changes.

Please review and test :-)

Thanks a lot!