### PR TITLE
Fix ParseUser logout() methode

### DIFF
--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -203,16 +203,16 @@ class ParseUser extends ParseObject implements ParseCloneable {
   /// Sends a request to delete the sessions token from the
   /// server. Will also delete the local user data unless
   /// deleteLocalUserData is false.
-  logout({bool deleteLocalUserData = true}) async {
-    if (deleteLocalUserData) {
+  Future<ParseResponse> logout({bool deleteLocalUserData = true}) async {
+    final String sessionId = _client.data.sessionId;
+
+    if (deleteLocalUserData == true) {
       _client.data.sessionId = null;
       unpin(key: keyParseStoreUser);
       setObjectData(null);
     }
 
     try {
-      if (username == null) return null;
-
       Uri tempUri = Uri.parse(_client.data.serverUrl);
 
       Uri url = Uri(
@@ -220,9 +220,8 @@ class ParseUser extends ParseObject implements ParseCloneable {
           host: tempUri.host,
           path: "${tempUri.path}$keyEndPointLogout");
 
-      final response = await _client.post(
-        url,
-      );
+      final response =
+          await _client.post(url, headers: {keyHeaderSessionToken: sessionId});
 
       return _handleResponse(
           this, response, ParseApiRQ.logout, _debug, className);

--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -206,8 +206,9 @@ class ParseUser extends ParseObject implements ParseCloneable {
   Future<ParseResponse> logout({bool deleteLocalUserData = true}) async {
     final String sessionId = _client.data.sessionId;
 
+    _client.data.sessionId = null;
+
     if (deleteLocalUserData == true) {
-      _client.data.sessionId = null;
       unpin(key: keyParseStoreUser);
       setObjectData(null);
     }


### PR DESCRIPTION
Fix for #83

- Set the return type to Future<ParseResponse>
- sessonId has to be stored and used locally because it is cleared inside the function
- check for username useless