### PR TITLE
ParseInstallation implementation

### DIFF
--- a/lib/parse_server_sdk.dart
+++ b/lib/parse_server_sdk.dart
@@ -13,6 +13,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:uuid/uuid.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:devicelocale/devicelocale.dart';
+import 'package:package_info/package_info.dart';
 
 part 'src/base/parse_constants.dart';
 
@@ -45,6 +47,8 @@ part 'src/objects/parse_object.dart';
 part 'src/objects/parse_response.dart';
 
 part 'src/objects/parse_user.dart';
+
+part 'src/objects/parse_installation.dart';
 
 part 'src/utils/parse_decoder.dart';
 

--- a/lib/src/base/parse_constants.dart
+++ b/lib/src/base/parse_constants.dart
@@ -28,6 +28,7 @@ const String keyVarAcl = 'ACL';
 // Classes
 const String keyClassMain = 'ParseMain';
 const String keyClassUser = '_User';
+const String keyClassInstallation = '_Installation';
 const String keyGeoPoint = 'GeoPoint';
 const String keyFile = 'File';
 
@@ -47,3 +48,4 @@ const String keyParamSessionToken = 'sessionToken';
 // Storage
 const String keyParseStoreBase = 'flutter_parse_sdk_';
 const String keyParseStoreUser = "${keyParseStoreBase}user";
+const String keyParseStoreInstallation = "${keyParseStoreBase}installation";

--- a/lib/src/objects/parse_installation.dart
+++ b/lib/src/objects/parse_installation.dart
@@ -1,0 +1,148 @@
+part of flutter_parse_sdk;
+
+class ParseInstallation extends ParseObject {
+  static final String keyTimeZone = 'timeZone';
+  static final String keyLocaleIdentifier = 'localeIdentifier';
+  static final String keyDeviceToken = 'deviceToken';
+  static final String keyDeviceType = 'deviceType';
+  static final String keyInstallationId = 'installationId';
+  static final String keyAppName = 'appName';
+  static final String keyAppVersion = 'appVersion';
+  static final String keyAppIdentifier = 'appIdentifier';
+  static final String keyParseVersion = 'parseVersion';
+  static final List<String> readOnlyKeys = [ //TODO
+    keyDeviceToken, keyDeviceType, keyInstallationId,
+    keyAppName, keyAppVersion, keyAppIdentifier, keyParseVersion
+  ];
+  static String _currentInstallationId;
+
+  //Getters/setters
+
+  Map get acl => super.get<Map>(keyVarAcl);
+
+  set acl(Map acl) => set<Map>(keyVarAcl, acl);
+
+  String get deviceToken => super.get<String>(keyDeviceToken);
+
+  set deviceToken(String deviceToken) => set<String>(keyDeviceToken, deviceToken);
+
+  String get deviceType => super.get<String>(keyDeviceType);
+
+  String get installationId => super.get<String>(keyInstallationId);
+
+  set _installationId(String installationId) => set<String>(keyInstallationId, installationId);
+
+  String get appName => super.get<String>(keyAppName);
+
+  String get appVersion => super.get<String>(keyAppVersion);
+
+  String get appIdentifier => super.get<String>(keyAppIdentifier);
+
+  String get parseVersion => super.get<String>(keyParseVersion);
+
+  /// Creates an instance of ParseInstallation
+  ParseInstallation(
+      {bool debug,
+      ParseHTTPClient client,
+      bool autoSendSessionId})
+      : super(keyClassInstallation) {
+    _debug = isDebugEnabled(objectLevelDebug: debug);
+    _client = client ??
+        ParseHTTPClient(
+            autoSendSessionId:
+                autoSendSessionId ?? ParseCoreData().autoSendSessionId,
+            securityContext: ParseCoreData().securityContext);
+  }
+
+  ParseInstallation.forQuery() : super(keyClassUser);
+
+  static Future<bool> isCurrent(ParseInstallation installation) async {
+    if (_currentInstallationId == null) {
+      _currentInstallationId = (await _getFromLocalStore()).installationId;
+    }
+    return _currentInstallationId != null && installation.installationId == _currentInstallationId;
+  }
+
+  /// Gets the current installation from storage
+  static Future<ParseInstallation> currentInstallation() async {
+    var installation = await _getFromLocalStore();
+    if (installation == null) {
+      installation = await _createInstallation();
+    }
+    return installation;
+  }
+
+  /// Updates the installation with current device data
+  _updateInstallation() async {
+    //Device type
+    if (Platform.isAndroid) set<String>(keyDeviceType, "android");
+    else if (Platform.isIOS) set<String>(keyDeviceType, "ios");
+    else throw Exception("Unsupported platform/operating system");
+
+    //Locale
+    String locale = await Devicelocale.currentLocale;
+    if (locale != null && locale.isNotEmpty) {
+      set<String>(keyLocaleIdentifier, locale);
+    }
+
+    //Timezone
+    //TODO set<String>(keyTimeZone, );
+
+    //App info
+    PackageInfo packageInfo = await PackageInfo.fromPlatform();
+    set<String>(keyAppName, packageInfo.appName);
+    set<String>(keyAppVersion, packageInfo.version);
+    set<String>(keyAppIdentifier, packageInfo.packageName);
+    set<String>(keyParseVersion, keySdkVersion);
+  }
+
+  Future<ParseResponse> create() async {
+    var isCurrent = await ParseInstallation.isCurrent(this);
+    if (isCurrent) await _updateInstallation();
+    ParseResponse parseResponse = await super.create();
+    if (parseResponse.success && isCurrent) {
+      saveInStorage(keyParseStoreInstallation);
+    }
+    return parseResponse;
+  }
+
+  /// Saves the current installation
+  Future<ParseResponse> save() async {
+    var isCurrent = await ParseInstallation.isCurrent(this);
+    if (isCurrent) await _updateInstallation();
+    ParseResponse parseResponse = await super.save();
+    if (parseResponse.success && isCurrent) {
+      saveInStorage(keyParseStoreInstallation);
+    }
+    return parseResponse;
+  }
+
+  /// Gets the locally stored installation
+  static Future<ParseInstallation> _getFromLocalStore() async {
+    var installationJson =
+        (await ParseCoreData().getStore()).getString(keyParseStoreInstallation);
+
+    if (installationJson != null) {
+      var installationMap = parseDecode(json.decode(installationJson));
+
+      if (installationMap != null) {
+        return new ParseInstallation()..fromJson(installationMap);
+      }
+    }
+
+    return null;
+  }
+
+  /// Creates a installation for current device
+  /// Assumes that this is called because there is no previous installation
+  /// so it creates and sets the static current installation UUID
+  static Future<ParseInstallation> _createInstallation() async {
+    if (_currentInstallationId == null) {
+      _currentInstallationId = Uuid().v4();
+    }
+    var installation = new ParseInstallation();
+    installation._installationId = _currentInstallationId;
+    await installation._updateInstallation();
+    return installation;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   shared_preferences: ^0.4.3
   path_provider: ^0.4.1
   uuid: ^1.0.3
+  package_info: ^0.4.0
+  devicelocale: ^0.1.1
 
 dev_dependencies:
   # Testing


### PR DESCRIPTION
This adds ParseInstallation class, one issue I have found is getting the TimeZone from flutter in same way that Parse Server excepts (Europe/Madrid). 

Also an dependency to deviceinfo was added to get Locale value from device using platform code, a better approach would be to add platform specific code in this library instead of using external libraries. This could also solve the problem with TimeZone as we could simply copy the way iOS/Android handles it.