### PR TITLE
Add fetch for ParseObject

### DIFF
--- a/lib/src/objects/parse_object.dart
+++ b/lib/src/objects/parse_object.dart
@@ -48,6 +48,11 @@ class ParseObject extends ParseBase implements ParseCloneable {
     }
   }
 
+  /// Fetches the object from the server into this object
+  Future<ParseResponse> fetch() async {
+    return await getObject(objectId);
+  }
+
   /// Gets all objects from this table - Limited response at the moment
   Future<ParseResponse> getAll() async {
     try {


### PR DESCRIPTION
This uses the standard fetch method from other sdks and eases the usage of pointers such as objA.get("pointerB").fetch();