### PR TITLE
Fix user clone issue.

### DIFF
--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -31,11 +31,6 @@ class ParseUser extends ParseObject implements ParseCloneable {
 
   ParseUser.forQuery() : super(keyClassUser);
 
-  @override
-  dynamic clone(Map<String, dynamic> map) {
-    return fromJson(map);
-  }
-
   static const String keyEmailVerified = 'emailVerified';
   static const String keyUsername = 'username';
   static const String keyEmailAddress = 'email';


### PR DESCRIPTION
The `clone` method in `ParseUser` doesn't create a new object like other 'clone' method. This issue leads to response results become the same one. (You can debug into `_handleSingleResult` method.)

I'm not sure this fix is absolutely correct, but this works fine in my project. Please check it carefully.