### PR TITLE
Hotfix `save`, `login` and `signUp`

### DIFF
--- a/lib/src/objects/parse_object.dart
+++ b/lib/src/objects/parse_object.dart
@@ -108,6 +108,7 @@ class ParseObject extends ParseBase implements ParseCloneable {
         else {
           _revertSavingChanges();
         }
+        return response;
       }
     }
     return childrenResponse;

--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -136,11 +136,13 @@ class ParseUser extends ParseObject implements ParseCloneable {
       bodyData[keyVarPassword] = password;
       bodyData[keyVarUsername] = username;
       final Uri url = getSanitisedUri(_client, '$path');
+      final String body = json.encode(bodyData);
+      _saveChanges();
       final Response response = await _client.post(url,
           headers: <String, String>{
             keyHeaderRevocableSession: '1',
           },
-          body: json.encode(bodyData));
+          body: body);
 
       return _handleResponse(
           this, response, ParseApiRQ.signUp, _debug, parseClassName);
@@ -162,7 +164,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
 
       final Uri url = getSanitisedUri(_client, '$keyEndPointLogin',
           queryParams: queryParams);
-
+      _saveChanges();
       final Response response =
           await _client.get(url, headers: <String, String>{
         keyHeaderRevocableSession: '1',
@@ -356,7 +358,6 @@ class ParseUser extends ParseObject implements ParseCloneable {
 
     final Map<String, dynamic> responseData = jsonDecode(response.body);
     if (responseData.containsKey(keyVarObjectId)) {
-      parseResponse.result.fromJson(responseData);
       user.sessionToken = responseData[keyParamSessionToken];
       ParseCoreData().setSessionId(user.sessionToken);
     }


### PR DESCRIPTION
1. Fix return result from save method. This is important.
2. Fix unsavedChanges issue in ParseUser login and signUp method.
3. Delete useless and reduplicative decode in ParseUser. Because this is already done in handleResponse method. This also cause wrong unsaved changes.