### PR TITLE
fix(LiveQuery): Session token null when subscribing

### DIFF
--- a/lib/src/network/parse_live_query.dart
+++ b/lib/src/network/parse_live_query.dart
@@ -117,7 +117,7 @@ class LiveQuery {
         'op': 'connect',
         'applicationId': _client.data.applicationId
       };
-      if (_sendSessionId) {
+      if (_sendSessionId && _client.data.sessionId != null) {
         _connectMessage['sessionToken'] = _client.data.sessionId;
       }
 
@@ -143,7 +143,7 @@ class LiveQuery {
             'fields': keysToReturn
         }
       };
-      if (_sendSessionId) {
+      if (_sendSessionId && _client.data.sessionId != null) {
         _subscribeMessage['sessionToken'] = _client.data.sessionId;
       }
 


### PR DESCRIPTION
When `autoSendSessionId: true`, it always sets the sessionToken header, even if `null`. However, when `null`, it throws an exception due to its unexpected type and breaks live query.

Below is the Flutter output when this happens:
```
I/flutter (12537): LiveQuery: : ConnectMessage: {op: connect, applicationId: myAppId, masterKey: 123456, sessionToken: null}

I/flutter (12537): LiveQuery: : SubscribeMessage: {op: subscribe, requestId: 1, query: {className: Diet_Plans, where: {objectId: 2pNUgv1CKA}}, sessionToken: null}

I/flutter (12537): LiveQuery: : Listen: {"op":"error","error":"Invalid type: null (expected string)","code":1,"reconnect":true}
```

Fixes #196