### PR TITLE
Allow adding additional columns to ParseUser through the set call

### DIFF
--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -131,10 +131,8 @@ class ParseUser extends ParseObject implements ParseCloneable {
         return null;
       }
 
-      final Map<String, dynamic> bodyData = <String, dynamic>{};
-      bodyData[keyVarEmail] = emailAddress;
-      bodyData[keyVarPassword] = password;
-      bodyData[keyVarUsername] = username;
+      final Map<String, dynamic> bodyData = _getObjectData();
+
       final Uri url = getSanitisedUri(_client, '$path');
       final String body = json.encode(bodyData);
       _saveChanges();


### PR DESCRIPTION
ParseUser("DummyUserName", "******", "dummyEmail@dummyemail.com")..set("userPhoneNumber", "123456789");

Currently ParseUser Signup only writes username, emailId, password to the User database and doesnt accept additional columns added through the .set(key, value) API even though the data is available in objectData.

Modifying the signup() code to accomodate for the same.