### PR TITLE
Allow adding additional columns to ParseUser through the set call

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,13 @@ Also, once logged in you can manage sessions tokens. This feature can be called 
 ```dart
 user = ParseUser.currentUser();
 ```
+
+To add additional columns to the user:
+```dart
+var user = ParseUser("TestFlutter", "TestPassword123", "TestFlutterSDK@gmail.com")
+            ..set("userLocation", "FlutterLand");
+```
+
 Other user features are:-
  * Request Password Reset
  * Verification Email Request

--- a/lib/src/objects/parse_user.dart
+++ b/lib/src/objects/parse_user.dart
@@ -136,10 +136,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
         return null;
       }
 
-      final Map<String, dynamic> bodyData = <String, dynamic>{};
-      bodyData[keyVarEmail] = emailAddress;
-      bodyData[keyVarPassword] = password;
-      bodyData[keyVarUsername] = username;
+      final Map<String, dynamic> bodyData = _getObjectData();
       final Uri url = getSanitisedUri(_client, '$path');
       final String body = json.encode(bodyData);
       _saveChanges();


### PR DESCRIPTION
Previous Pull Request: https://github.com/phillwiggins/flutter_parse_sdk/pull/231
Pull Request Details:
var user = ParseUser("TestFlutter", "TestPassword123", "TestFlutterSDK@gmail.com")
            ..set("userLocation", "FlutterLand");

Currently ParseUser Signup only writes username, email Id, password to the User database and doesn't accept additional columns added through the .set(key, value) API even though the data is available in objectData.

Modifying the signup() code to accommodate for the same.