### PR TITLE
ParseFile should NOT extends ParseObject.

### DIFF
--- a/lib/src/objects/parse_base.dart
+++ b/lib/src/objects/parse_base.dart
@@ -23,7 +23,7 @@ abstract class ParseBase {
   }
 
   bool _isDirty(bool considerChildren) {
-    if (_dirty || _unsavedChanges.isNotEmpty) {
+    if (_dirty || _unsavedChanges.isNotEmpty || objectId == null) {
       return true;
     }
 

--- a/lib/src/objects/parse_file.dart
+++ b/lib/src/objects/parse_file.dart
@@ -1,6 +1,6 @@
 part of flutter_parse_sdk;
 
-class ParseFile extends ParseObject {
+class ParseFile extends ParseBase {
   /// Creates a new file
   ///
   /// {https://docs.parseplatform.org/rest/guide/#files/}
@@ -9,8 +9,7 @@ class ParseFile extends ParseObject {
       String url,
       bool debug,
       ParseHTTPClient client,
-      bool autoSendSessionId})
-      : super(keyFile) {
+      bool autoSendSessionId}) {
     _debug = isDebugEnabled(objectLevelDebug: debug);
     _client = client ??
         ParseHTTPClient(
@@ -27,6 +26,9 @@ class ParseFile extends ParseObject {
     }
   }
 
+  bool _debug;
+  ParseHTTPClient _client;
+  
   File file;
 
   String get name => super.get<String>(keyVarName);


### PR DESCRIPTION
`ParseObject` should be a table in database on parse server, but `ParseFile` can't be a table.
I had found implementation of `PFFileObject` in iOS/OSX SDK, it's NOT a subclass of 'PFObject'.
When `ParseFile` extends from `ParseObject`, it cause an infinite loop in `save()` method.