### PR TITLE
fix ParseCloudFunction execute and executeObjectFunction headers fail

### DIFF
--- a/lib/src/objects/parse_function.dart
+++ b/lib/src/objects/parse_function.dart
@@ -27,14 +27,14 @@ class ParseCloudFunction extends ParseObject {
   ///
   /// To add the parameters, create an object and call [set](value to set)
   Future<ParseResponse> execute(
-      {Map<String, dynamic> parameters, Map<String, dynamic> headers}) async {
+      {Map<String, dynamic> parameters, Map<String, String> headers}) async {
     final String uri = '${_client.data.serverUrl}$_path';
     if (parameters != null) {
       _setObjectData(parameters);
     }
 
-    final Response result =
-    await _client.post(uri, body: json.encode(_getObjectData()));
+    final Response result = await _client.post(uri,
+        headers: headers, body: json.encode(_getObjectData()));
     return handleResponse<ParseCloudFunction>(
         this, result, ParseApiRQ.execute, _debug, parseClassName);
   }
@@ -43,14 +43,14 @@ class ParseCloudFunction extends ParseObject {
   ///
   /// To add the parameters, create an object and call [set](value to set)
   Future<ParseResponse> executeObjectFunction<T extends ParseObject>(
-      {Map<String, dynamic> parameters, Map<String, dynamic> headers}) async {
+      {Map<String, dynamic> parameters, Map<String, String> headers}) async {
     final String uri = '${_client.data.serverUrl}$_path';
     if (parameters != null) {
       _setObjectData(parameters);
     }
-    final Response result =
-        await _client.post(uri, body: json.encode(_getObjectData()));
-    return handleResponse<T>(
-        this, result, ParseApiRQ.executeObjectionFunction, _debug, parseClassName);
+    final Response result = await _client.post(uri,
+        headers: headers, body: json.encode(_getObjectData()));
+    return handleResponse<T>(this, result, ParseApiRQ.executeObjectionFunction,
+        _debug, parseClassName);
   }
 }


### PR DESCRIPTION
hi ! brother,I'm come again !
today,When I used ParseCloudFunction, I encountered a problem, the headers parameter failed,and  I fixed it.
code:
```
    final ParseCloudFunction parseCloud = ParseCloudFunction('functionName');
    final Map<String, String> params = <String, String>{
      'objectId': '5b625c781235522020dbbad9c',
    };
    final Map<String, String> headers = <String, String>{
      "content-type": 'application/json'
    };
    final ParseResponse result =
        await parseCloud.execute(parameters: params,headers: headers);
```
from
request.headers :{content-type: text/plain; charset=utf-8}
now 
request.headers :{content-type: application/json; charset=utf-8}
and the function it's work

At last :look forward to your reply 
