### PR TITLE
Bug fix.

### DIFF
--- a/lib/src/objects/parse_base.dart
+++ b/lib/src/objects/parse_base.dart
@@ -186,7 +186,7 @@ abstract class ParseBase {
   /// To set an int, call setType<int> and an int will be saved
   /// [bool] forceUpdate is always true, if unsure as to whether an item is
   /// needed or not, set to false
-  void set<T>(String key, T value, {bool forceUpdate = false}) {
+  void set<T>(String key, T value, {bool forceUpdate = true}) {
     if (value != null) {
       if (_getObjectData().containsKey(key)) {
         if (_getObjectData()[key] == value && !forceUpdate) {


### PR DESCRIPTION
Bug fix: 'set' method should force update by default. If someone change a property of object from 'get' method and then 'set' it in ParseObject, it should be dirty.
