### PR TITLE
ParseObject.update/ParseInstallation.create/ParseSession.installationId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .dart_tool/
-
+.history
 .packages
 .pub/
 pubspec.lock

--- a/lib/src/objects/parse_installation.dart
+++ b/lib/src/objects/parse_installation.dart
@@ -9,7 +9,7 @@ class ParseInstallation extends ParseObject {
     _client = client ??
         ParseHTTPClient(
             sendSessionId:
-            autoSendSessionId ?? ParseCoreData().autoSendSessionId,
+                autoSendSessionId ?? ParseCoreData().autoSendSessionId,
             securityContext: ParseCoreData().securityContext);
   }
 
@@ -130,11 +130,11 @@ class ParseInstallation extends ParseObject {
     final CoreStore coreStore = await ParseCoreData().getStore();
 
     final String installationJson =
-    await coreStore.getString(keyParseStoreInstallation);
+        await coreStore.getString(keyParseStoreInstallation);
 
     if (installationJson != null) {
       final Map<String, dynamic> installationMap =
-      json.decode(installationJson);
+          json.decode(installationJson);
 
       if (installationMap != null) {
         return ParseInstallation()..fromJson(installationMap);
@@ -161,11 +161,16 @@ class ParseInstallation extends ParseObject {
     try {
       final String uri = '${_client.data.serverUrl}$keyEndPointInstallations';
       final String body = json.encode(toJson(forApiRQ: true));
+      final Map<String, String> headers = {
+        keyHeaderContentType: keyHeaderContentTypeJson
+      };
       if (_debug) {
         logRequest(ParseCoreData().appName, parseClassName,
             ParseApiRQ.create.toString(), uri, body);
       }
-      final Response result = await _client.post(uri, body: body);
+
+      final Response result =
+          await _client.post(uri, body: body, headers: headers);
 
       //Set the objectId on the object after it is created.
       //This allows you to perform operations on the object after creation

--- a/lib/src/objects/parse_object.dart
+++ b/lib/src/objects/parse_object.dart
@@ -82,7 +82,9 @@ class ParseObject extends ParseBase implements ParseCloneable {
       final Uri url = getSanitisedUri(_client, '$_path/$objectId');
       final String body = json.encode(toJson(forApiRQ: true));
       _saveChanges();
-      final Response result = await _client.put(url, body: body);
+      final Map<String, String> headers = {keyHeaderContentType:keyHeaderContentTypeJson};
+      final Response result =
+          await _client.put(url, body: body, headers: headers);
       return handleResponse<ParseObject>(
           this, result, ParseApiRQ.save, _debug, parseClassName);
     } on Exception catch (e) {
@@ -104,8 +106,7 @@ class ParseObject extends ParseBase implements ParseCloneable {
       if (response != null) {
         if (response.success) {
           _savingChanges.clear();
-        }
-        else {
+        } else {
           _revertSavingChanges();
         }
         return response;
@@ -175,8 +176,7 @@ class ParseObject extends ParseBase implements ParseCloneable {
             if (response.results[i] is ParseError) {
               // Batch request succeed, but part of batch failed.
               chunk[i]._revertSavingChanges();
-            }
-            else {
+            } else {
               chunk[i]._savingChanges.clear();
             }
           }

--- a/lib/src/objects/parse_session.dart
+++ b/lib/src/objects/parse_session.dart
@@ -29,12 +29,9 @@ class ParseSession extends ParseObject implements ParseCloneable {
 
   Future<ParseResponse> getCurrentSessionFromServer() async {
     try {
-      final Uri tempUri = Uri.parse(_client.data.serverUrl);
 
-      final Uri url = Uri(
-          scheme: tempUri.scheme,
-          host: tempUri.host,
-          path: '${tempUri.path}$keyEndPointSessions/me');
+      const String path = '$keyEndPointSessions/me';
+      final Uri url = getSanitisedUri(_client, path);
 
       final Response response = await _client.get(url);
 

--- a/lib/src/objects/parse_session.dart
+++ b/lib/src/objects/parse_session.dart
@@ -27,6 +27,10 @@ class ParseSession extends ParseObject implements ParseCloneable {
 
   String get installationId => super.get<String>(keyVarInstallationId);
 
+  set installationId(String installationId) =>
+      set<String>(keyVarInstallationId, installationId);
+
+
   Future<ParseResponse> getCurrentSessionFromServer() async {
     try {
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-    
+
   # Networking
   web_socket_channel: ^1.0.9
   http: ^0.12.0


### PR DESCRIPTION
hi,brother!
Here are some changes I made.
* Add a header to the ParseObject.update and ParseInstallation.create
It's fix some bug about when I use them,return "request body is empty"

> Actually:[For POST and PUT requests, the request body must be JSON, with the Content-Type header set to application/json.](https://docs.parseplatform.org/rest/guide/#request-format),but I don't know much about this.I am worried that if I change all of them, there will be some errors that I don't understand, so I only changed the method I am currently using.

* ParseSession add set installationId
so now:
```
final ParseSession parseSession = ParseSession();
    var res = await parseSession.getCurrentSessionFromServer();
    if (res.success) {
      final ParseInstallation installation =
          await ParseInstallation.currentInstallation();
      parseSession.installationId = installation.installationId;
      parseSession.save();
    } else {
      print(res.error);
    }
```


look forward to your reply,hava a good day!
